### PR TITLE
pcap: name file <sid>.pcap if sid is available

### DIFF
--- a/decoders.go
+++ b/decoders.go
@@ -49,6 +49,12 @@ type SuricataJsonEvent struct {
 	SourcePort uint16 `json:"src_port"`
 	DestAddr   string `json:"dest_ip"`
 	DestPort   uint16 `json:"dest_port"`
+
+	Alert SuricataJsonAlert `json:"alert"`
+}
+
+type SuricataJsonAlert struct {
+	SignatureId uint32 `json:"signature_id"`
 }
 
 type Event struct {
@@ -58,6 +64,7 @@ type Event struct {
 	SourcePort uint16
 	DestAddr   string
 	DestPort   uint16
+	SignatureId uint32
 
 	// The original event.
 	Original string
@@ -155,6 +162,7 @@ func DecodeSuricataJsonEvent(buf string) *Event {
 		SourcePort: suricataJsonEvent.SourcePort,
 		DestAddr:   suricataJsonEvent.DestAddr,
 		DestPort:   suricataJsonEvent.DestPort,
+		SignatureId: suricataJsonEvent.Alert.SignatureId,
 		Original:   buf,
 	}
 }


### PR DESCRIPTION
So when getting a capture for sid 2210054, the file would be called
2210054.pcap. This makes it more convenient to store the files.

Implemented for Eve, when the sid is taken from alert.signature_id.