### PR TITLE
build(deps): Dependabot staging - axum, tokio, clap, rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = { version = "0.8", default-features = false, features = ["json", "form", 
 axum-server = { version = "0.8", default-features = false, features = ["tls-rustls"] }
 base64 = { version = "0.22.1", default-features = false }
 bcrypt = { version = "0.19.0", default-features = false, features = ["std"] }
-clap = { version = "4.6.0", default-features = false, features = ["std", "derive", "color", "help", "usage"] }
+clap = { version = "4.6.1", default-features = false, features = ["std", "derive", "color", "help", "usage"] }
 futures-util = { version = "0.3.32", default-features = false }
 lazy_static = "1.5.0"
 mime_guess = { version = "2.0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = { version = "1.0.149", default-features = false, features = [] }
 serde_yaml = { version = "0.9.34", default-features = false, features = [] }
 thiserror = "2.0.18"
 time = { version = "0.3.47", default-features = false, features = ["parsing", "local-offset", "macros"] }
-tokio = { version = "1.51.1", default-features = false, features = ["macros", "rt-multi-thread", "full"] }
+tokio = { version = "1.52.1", default-features = false, features = ["macros", "rt-multi-thread", "full"] }
 tokio-stream = { version = "0.1.18", default-features = false, features = [] }
 tokio-util = { version = "0.7.18", default-features = false, features = ["io"] }
 tracing = { version = "0.1.44", default-features = false, features = [] }

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -190,7 +190,7 @@ fn collect_pcap_files(directory: &str, prefix: Option<&str>) -> Result<Vec<FileI
     }
 
     // Sort by modification time, newest first
-    files.sort_by(|a, b| b.modified.cmp(&a.modified));
+    files.sort_by_key(|b| std::cmp::Reverse(b.modified));
 
     Ok(files)
 }


### PR DESCRIPTION
Combines 4 Dependabot dependency updates into a single staging PR:

- #130 bump axum from 0.8.8 to 0.8.9
- #132 bump tokio from 1.51.1 to 1.52.1
- #133 bump clap from 4.6.0 to 4.6.1
- #134 bump rustls-webpki from 0.103.11 to 0.103.13 (security fix)

All commits cherry-picked without merge commits. Build verified locally.